### PR TITLE
Add another optional argument for test_suite

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   path:
     description: An assignment path within the repository.
     required: false
+  test_suite:
+    description: A test_suite name within the repository.
+    default: 'autograding'
 runs:
   using: "node12"
   main: "./dist/index.js"

--- a/src/autograding.ts
+++ b/src/autograding.ts
@@ -10,13 +10,18 @@ const run = async (): Promise<void> => {
       throw new Error('No GITHUB_WORKSPACE')
     }
 
-    const assignmentPath = core.getInput("path")
+    const assignmentPath = core.getInput('path')
     if (assignmentPath) {
       console.log(`Using assignment path: ${assignmentPath}`)
       cwd = path.join(cwd, assignmentPath)
     }
 
-    const data = fs.readFileSync(path.resolve(cwd, '.github/classroom/autograding.json'))
+    let testSuite = core.getInput('test_suite')
+    if (!testSuite) {
+      testSuite = 'autograding'
+    }
+
+    const data = fs.readFileSync(path.resolve(cwd, '.github/classroom/${testSuite}.json'))
     const json = JSON.parse(data.toString())
 
     await runAll(json.tests as Array<Test>, cwd)


### PR DESCRIPTION
I have added an option to specify the test_suite file that should be run for any autograding job. With this, for the extra credit evaluation, we can pass a separate extra_credit.json file path which will contain test-cases corresponding to extra credit.